### PR TITLE
Add cipher_algo to Openssl_seal for PHP8

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -172,7 +172,7 @@ class Api {
 
     $public_key = $this->getPublicKey();
 
-    $result = openssl_seal($plaintext, $message, $keys, array($public_key));
+    $result = openssl_seal($plaintext, $message, $keys, array($public_key), 'RC4');
 
     if ($result === FALSE || empty($keys[0]) || empty($message) || $message === $plaintext) {
       throw new EncryptionException('Unable to encrypt a message: ' . openssl_error_string());


### PR DESCRIPTION
Since PHP8 cipher_algo is now required in openssl_seal method. Added back the default value which is RC4, although it is currently marked as Insecure on php.net.